### PR TITLE
Better result entry

### DIFF
--- a/app/assets/stylesheets/multiselect.css
+++ b/app/assets/stylesheets/multiselect.css
@@ -7,7 +7,7 @@
   background: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>") no-repeat right #ddd;
   background-color: white;
   appearance: none;
-  border: 1px solid rgb(218 218 218);
+  border: 1px solid var(--color-neutral-800);
   outline-offset: 2px;
   outline: transparent solid 2px;
   color: rgb(55 61 63);
@@ -195,7 +195,6 @@
   border: 1px solid rgb(218 218 218);
   width: 100%;
   display: none;
-  margin-top: 0.5rem;
   z-index: 50;
   position: absolute;
 }

--- a/app/assets/stylesheets/multiselect.css
+++ b/app/assets/stylesheets/multiselect.css
@@ -6,7 +6,6 @@
   padding-left: 0.5rem;
   background: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>") no-repeat right #ddd;
   background-color: white;
-  border-radius: 0.25rem;
   appearance: none;
   border: 1px solid rgb(218 218 218);
   outline-offset: 2px;
@@ -17,6 +16,7 @@
   font-weight: 400;
   font-size: 0.875rem;
   cursor: pointer;
+  min-width: 32rem;
 }
 
 .multiselect__no-result {
@@ -75,14 +75,11 @@
   padding-left: 0.5rem;
   background-color: rgb(250 249 244);
   border: 1px solid #f0f0f0;
-  border-radius: 0.25rem;
   display: flex;
 }
 
 .multiselect__pill-delete {
   padding: 0.25rem 0.5rem 0.25rem 0.5rem;
-  border-top-right-radius: 0.25rem;
-  border-bottom-right-radius: 0.25rem;
   align-items: center;
   display: flex;
   margin-left: 0.25rem;
@@ -186,16 +183,6 @@
   display: flex;
 }
 
-.multiselect__list li:first-child {
-  border-top-left-radius: 0.25rem;
-  border-top-right-radius: 0.25rem;
-}
-
-.multiselect__list li:last-child {
-  border-bottom-left-radius: 0.25rem;
-  border-bottom-right-radius: 0.25rem;
-}
-
 .multiselect__list li input {
   margin-right: 0.75rem;
 }
@@ -207,7 +194,6 @@
   background-color: rgb(255 255 255);
   border: 1px solid rgb(218 218 218);
   width: 100%;
-  border-radius: 0.25rem;
   display: none;
   margin-top: 0.5rem;
   z-index: 50;

--- a/app/assets/stylesheets/multiselect.css
+++ b/app/assets/stylesheets/multiselect.css
@@ -1,0 +1,219 @@
+.multiselect__container {
+  font-family: sans-serif;
+  padding-top: 0.4rem;
+  padding-bottom: 0.4rem;
+  padding-right: 1.75rem;
+  padding-left: 0.5rem;
+  background: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>") no-repeat right #ddd;
+  background-color: white;
+  border-radius: 0.25rem;
+  appearance: none;
+  border: 1px solid rgb(218 218 218);
+  outline-offset: 2px;
+  outline: transparent solid 2px;
+  color: rgb(55 61 63);
+  line-height: 1.5;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.multiselect__no-result {
+  color: rgb(112 112 112);
+  padding: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.multiselect__addable-button {
+  padding: 0.5rem;
+  text-decoration-line: underline;
+  color: rgb(55 61 63);
+  cursor: pointer;
+}
+
+.multiselect__addable-button:hover {
+  color: rgb(29 115 186);
+}
+
+.multiselect__container:focus-within {
+  border-color: rgb(44 141 222);
+  --tw-shadow:  0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --tw-shadow-colored:  0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.multiselect__container--disabled {
+  background-color: rgb(240 240 240);
+  cursor: not-allowed;
+}
+
+.multiselect__container:hover {
+  --tw-shadow:  0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  --tw-shadow-colored:  0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.multiselect__hidden {
+  display: none;
+}
+
+.multiselect__preview {
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: -webkit-fill-available;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.multiselect__pill {
+  max-width: fill-available;
+  color: rgb(55 61 63);
+  font-size: 1.5rem;
+  padding-left: 0.5rem;
+  background-color: rgb(250 249 244);
+  border: 1px solid #f0f0f0;
+  border-radius: 0.25rem;
+  display: flex;
+}
+
+.multiselect__pill-delete {
+  padding: 0.25rem 0.5rem 0.25rem 0.5rem;
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+  align-items: center;
+  display: flex;
+  margin-left: 0.25rem;
+}
+
+.multiselect__pill-delete:hover {
+  background-color: rgb(254 178 178);
+}
+
+.multiselect__pill:hover svg{
+  fill: rgb(246, 71, 71);
+}
+
+.multiselect__pill-text {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.multiselect__input-container {
+  display: flex;
+}
+
+.multiselect__focused {
+  background-color: #f4fbff;
+}
+
+.multiselect__placeholder {
+  color: rgb(174 174 174);
+  font-style: italic;
+  padding-left: 0.25rem;
+  opacity: 1;
+}
+
+.multiselect__addable {
+  text-decoration-line: underline;
+  color: rgb(112 112 112);
+  text-align: center;
+}
+
+.multiselect__addable:hover {
+  color: rgb(55 61 63);
+}
+
+.multiselect__search {
+  width: 100%;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  border: transparent;
+  color: rgb(55 61 63);
+  font-size: 1.5rem;
+  padding-left: 0.25rem;
+}
+
+.multiselect__search:focus::placeholder {
+  color: rgb(112 112 112);
+}
+
+.multiselect__search:disabled {
+  background-color: rgb(240 240 240);
+  cursor: not-allowed;
+}
+
+.multiselect__search::placeholder {
+  font-style: italic;
+  opacity: 1;
+  color: rgb(174 174 174);
+}
+
+.multiselect__list {
+  max-height: 400px;
+  overflow-y: auto;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.multiselect__list li {
+  display: block;
+  align-items: center;
+  font-size: 1.25rem;
+  color: rgb(112 112 112);
+  border-top-width: 1;
+}
+
+
+.multiselect__list li:first {
+  border-top-width: 0;
+}
+
+.multiselect__list li:hover {
+  background-color: rgb(244 251 255);
+}
+
+.multiselect__list li label {
+  padding: 0.75rem;
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+}
+
+.multiselect__list li:first-child {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.multiselect__list li:last-child {
+  border-bottom-left-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.multiselect__list li input {
+  margin-right: 0.75rem;
+}
+
+.multiselect__dropdown {
+  --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  background-color: rgb(255 255 255);
+  border: 1px solid rgb(218 218 218);
+  width: 100%;
+  border-radius: 0.25rem;
+  display: none;
+  margin-top: 0.5rem;
+  z-index: 50;
+  position: absolute;
+}
+
+.multiselect__dropdown--open {
+  display: block;
+}

--- a/app/assets/stylesheets/multiselect.css
+++ b/app/assets/stylesheets/multiselect.css
@@ -22,7 +22,6 @@
 .multiselect__no-result {
   color: rgb(112 112 112);
   padding: 0.75rem;
-  font-size: 0.875rem;
 }
 
 .multiselect__addable-button {
@@ -157,6 +156,7 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+  font-size: 1.5rem;
 }
 
 .multiselect__list li {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -20,45 +20,47 @@ html, body, #container {
   @apply grow;
 }
 
-h1 {
-  @apply text-2xl;
-}
-
-h2 {
-  @apply text-xl;
-}
-
-h3 {
-  @apply text-lg;
-}
-
-input, select, textarea {
-  @apply border bg-white text-neutral-800 p-2;
-
-  &.disabled, &:disabled {
-    @apply text-neutral-500;
-  }
-}
-
-.btn {
-  @apply inline-block p-2 bg-blue-600 hover:bg-blue-500 text-white hover:text-white cursor-pointer;
-
-  &.btn-primary {
-    @apply bg-champion hover:bg-yellow-400;
+@layer components {
+  h1 {
+    @apply text-2xl;
   }
 
-  &.btn-danger {
-    @apply bg-red-500 hover:bg-red-400
+  h2 {
+    @apply text-xl;
   }
-}
+
+  h3 {
+    @apply text-lg;
+  }
+
+  input, select, textarea {
+    @apply border bg-white text-neutral-800 p-2;
+
+    &.disabled, &:disabled {
+      @apply text-neutral-500;
+    }
+  }
+
+  .btn {
+    @apply inline-block p-2 bg-blue-600 hover:bg-blue-500 text-white hover:text-white cursor-pointer;
+
+    &.btn-primary {
+      @apply bg-champion hover:bg-yellow-400;
+    }
+
+    &.btn-danger {
+      @apply bg-red-500 hover:bg-red-400
+    }
+  }
 
 
-a {
-  @apply text-blue-500 hover:text-blue-400
-}
+  a {
+    @apply text-blue-500 hover:text-blue-400
+  }
 
-header a {
-  @apply text-white hover:text-neutral-200;
+  header a {
+    @apply text-white hover:text-neutral-200;
+  }
 }
 
 .score-red-wins {

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -14,11 +14,24 @@ class PlayersController < ApplicationController
 
   def create
     @player = Player.new(player_params)
+    saved = @player.save
 
-    if @player.save
-      redirect_to players_path
-    else
-      render :new, status: :unprocessable_entity
+    respond_to do |f|
+      f.html do
+        if saved
+          redirect_to players_path
+        else
+          render :new, status: :unprocessable_entity
+        end
+      end
+
+      f.json do
+        if saved
+          render json: { text: @player.name, value: @player.id }
+        else
+          render json: { errors: @player.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
     end
   end
 

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -2,7 +2,14 @@ class PlayersController < ApplicationController
   before_action :set_player, only: [:edit, :destroy, :show, :update]
 
   def index
-    @players = Player.order(id: :desc)
+    @players = Player.order(:name)
+
+    @players = @players.where('name LIKE ?', "#{params[:q]}%") if params[:q]
+
+    respond_to do |f|
+      f.html
+      f.json { render json: @players.map { |p| { value: p.id, text: p.name } } }
+    end
   end
 
   def create

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -45,11 +45,7 @@ class PlayersController < ApplicationController
 
   def destroy
     @player.destroy
-
-    respond_to do |f|
-      f.turbo_stream { render turbo_stream: turbo_stream.remove(@player) }
-      f.html { redirect_to players_path }
-    end
+    redirect_to players_path
   end
 
   def edit

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -10,7 +10,6 @@ class ResultsController < ApplicationController
       redirect_to game_path(@game)
     else
       @result = response.result
-      p @result.teams
       @result.teams.build while @result.teams.length < max_number_of_teams
       render :new, status: 422
     end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,6 +1,8 @@
 class ResultsController < ApplicationController
   before_action :set_game
 
+  helper_method :team_game?
+
   def create
     response = ResultService.create(@game, params[:result])
 
@@ -8,27 +10,35 @@ class ResultsController < ApplicationController
       redirect_to game_path(@game)
     else
       @result = response.result
-      render :new
+      p @result.teams
+      @result.teams.build while @result.teams.length < max_number_of_teams
+      render :new, status: 422
     end
   end
 
   def destroy
     result = @game.results.find_by_id(params[:id])
-
-    response = ResultService.destroy(result)
-
+    ResultService.destroy(result)
     redirect_to request.referer
   end
 
   def new
     @result = Result.new
-    (@game.max_number_of_teams || 20).times{|i| @result.teams.build}
-    @team_game = @game.max_number_of_players_per_team != 1
+    max_number_of_teams.times{@result.teams.build}
   end
 
   private
 
   def set_game
     @game = Game.find(params[:game_id])
+  end
+
+  def team_game?
+    set_game
+    @game.max_number_of_players_per_team != 1
+  end
+
+  def max_number_of_teams
+    @game.max_number_of_teams || 20
   end
 end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,8 @@
 import { Application } from "@hotwired/stimulus"
+import { Multiselect } from "@wizardhealth/stimulus-multiselect";
 
 const application = Application.start()
+application.register('multiselect', Multiselect);
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,8 +1,6 @@
 import { Application } from "@hotwired/stimulus"
-import { Multiselect } from "@wizardhealth/stimulus-multiselect";
 
 const application = Application.start()
-application.register('multiselect', Multiselect);
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/javascript/controllers/multiselect_controller.js
+++ b/app/javascript/controllers/multiselect_controller.js
@@ -1,0 +1,34 @@
+import { Multiselect } from "@wizardhealth/stimulus-multiselect";
+
+const getCSRFParam = () => document.querySelector("meta[name='csrf-token']").getAttribute("content");
+
+export default class extends Multiselect {
+
+  // Override the less-than-useful superclass implementation so we can actually
+  // access the data we need, etc...
+  addableEvent() {
+    super.addableEvent();
+
+    console.log(this.searchTarget.value, this.addableUrlValue);
+
+    fetch(this.addableUrlValue, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": getCSRFParam()
+      },
+      body: JSON.stringify({ player: { name: this.searchTarget.value } })
+    }).then(
+      result => {
+        result.json().then(
+          json => {
+            if (!json.errors) {
+              this.addAddableItem(json);
+            }
+          }
+        )
+      }
+    )
+  }
+
+}

--- a/app/javascript/controllers/multiselect_controller.js
+++ b/app/javascript/controllers/multiselect_controller.js
@@ -9,8 +9,6 @@ export default class extends Multiselect {
   addableEvent() {
     super.addableEvent();
 
-    console.log(this.searchTarget.value, this.addableUrlValue);
-
     fetch(this.addableUrlValue, {
       method: "POST",
       headers: {

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -24,13 +24,6 @@ class Player < ApplicationRecord
   validates :name, uniqueness: true, presence: true
   validates :email, allow_blank: true, format: { with: /@/, message: "expected an @ character" }
 
-  def as_json
-    {
-      name: name,
-      email: email
-    }
-  end
-
   def recent_results
     results.order("results.created_at DESC").limit(5)
   end
@@ -83,23 +76,23 @@ class Player < ApplicationRecord
     results = self.results.where(game_id: game)
 
     for result in results
-      # Identify whether this match was a win, loss or draw 
+      # Identify whether this match was a win, loss or draw
       won_game = result.winners.include?(self) && !result.tie?
       lost_game = !result.winners.include?(self) && !result.tie?
       tie_game = result.tie?
 
       # Continue win streak if we're on one
-      if (won_game and currentStreak.win) 
+      if (won_game and currentStreak.win)
         # Add to win streak
         currentStreak.resultTimes.append(result.created_at)
         # Add to current unbeaten streak
         currentStreakUnbeaten.resultTimes.append(result.created_at)
       # Continue loss streak if we're on one
       elsif (lost_game and not currentStreak.win)
-        # Add to loss streak 
+        # Add to loss streak
         currentStreak.resultTimes.append(result.created_at)
       # Add to unbeaten run if we're on one
-      elsif tie_game and currentStreak.win 
+      elsif tie_game and currentStreak.win
         # Add to current unbeaten streak
         currentStreakUnbeaten.resultTimes.append(result.created_at)
       end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -44,7 +44,7 @@ class Result < ApplicationRecord
 
   def verdict
     # Check for a score draw
-    if self.against == self.for
+    if self.against == self.for || against.nil? || self.for.nil?
       # They drew, select all players involved
       winteam = ''
       loseteam = ''

--- a/app/services/result_service.rb
+++ b/app/services/result_service.rb
@@ -21,8 +21,6 @@ class ResultService
       result.loseteam.winner = false
     end
 
-    p result.teams
-
     if result.valid?
       Result.transaction do
         game.rater.update_ratings game, result

--- a/app/services/result_service.rb
+++ b/app/services/result_service.rb
@@ -2,7 +2,6 @@ class ResultService
   def self.create(game, params)
     result = game.results.build
 
-
     teams = (params[:teams] || {}).values.each.with_object([]) do |team, acc|
       players = Array.wrap(team[:players]).delete_if(&:blank?)
       acc << { players: players }
@@ -17,10 +16,12 @@ class ResultService
     result.for = params[:for]
     result.against = params[:against]
 
-    if ! result.tie?
+    unless result.tie?
       result.winteam.winner = true
       result.loseteam.winner = false
     end
+
+    p result.teams
 
     if result.valid?
       Result.transaction do

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -7,7 +7,7 @@
     <section class="p-4 flex justify-end">
       <span><%= link_to 'Edit Player', edit_player_path(@player), data: { turbo_frame: dom_id(@player) }, class: "btn" %></span>
       <% if @player.results.empty? %>
-        <span><%= link_to "Delete", player_path(@player), method: :delete, confirm: "Are you sure?", class: "btn btn-danger" %></span>
+        <span><%= link_to "Delete", player_path(@player), data: { "turbo-method": :delete, "turbo-confirm": "Are you sure?" }, class: "btn btn-danger" %></span>
       <% end %>
     </section>
   <% end %>

--- a/app/views/results/new.html.erb
+++ b/app/views/results/new.html.erb
@@ -3,10 +3,10 @@
   <% if @team_game %>
     <h1 class="mb-4">Team Results</h1>
     <p>
-    This game supports team results. This means that you can either select a singular player per team, or multiple.
-    There is a known issue with this form. If you attempt to submit and nothing happens, it is likely that you have selected the same player in multiple teams.
-    To select multiple players per team, use "shift + click", or "cmd + click" on mac, or "ctrl + click" on windows machines.
-    <% if @result.teams.length > 2 %>You do not need to fill in every team, start on the far left and move towards the right, the minimum requirement is the first two, then the rest are optional.<% end %>
+      This game supports team results. This means that you can either select a singular player per team, or multiple.
+      <% if @result.teams.length > 2 %>
+        You do not need to fill in every team, start on the far left and move towards the right, the minimum requirement is the first two, then the rest are optional.
+      <% end %>
     </p>
   <% end %>
 
@@ -18,15 +18,37 @@
             Team <%= index + 1 %>
           </h3>
           <div class="flex justify-center items-center gap-8">
-            <%=
-              select "result[teams][#{index}]",
-                     "players",
-                     player_options,
-                     {include_blank: false},
-                     class: "w-48 text-lg",
-                     multiple: @team_game,
-                     "data-placeholder" => "Team #{index + 1}"
-            %>
+
+            <% if @team_game %>
+              <div
+                data-controller="multiselect"
+                data-multiselect-preload-url-value="<%= players_path(format: :json) %>"
+                data-multiselect-search-url-value="<%= players_path(format: :json) %>"
+                data-placeholder="Search for players..."
+              >
+                <%=
+                  select "result[teams][#{index}]",
+                        "players",
+                        [],
+                        {},
+                        class: "multiselect__hidden",
+                        multiple: true,
+                        data: {
+                          "multiselect-target": "hidden"
+                        }
+                %>
+              </div>
+            <% else %>
+                <%=
+                  select "result[teams][#{index}]",
+                         "players",
+                         player_options,
+                         {include_blank: false},
+                         class: "w-48 text-lg",
+                         "data-placeholder" => "Team #{index + 1}"
+                %>
+            <% end %>
+
             <% if index == 0 %>
               <%= f.number_field :for, step: 1, min: 0, class: "w-16" %>
             <% else %>

--- a/app/views/results/new.html.erb
+++ b/app/views/results/new.html.erb
@@ -45,7 +45,9 @@
 
             <% if team_game? %>
               <div
+                data-addable-placeholder="Add new player"
                 data-controller="multiselect"
+                data-multiselect-addable-url-value=<%= players_path(format: :json) %>
                 data-multiselect-preload-url-value="<%= players_path(format: :json) %>"
                 data-multiselect-search-url-value="<%= players_path(format: :json) %>"
                 data-multiselect-selected-value="<%= team.players.map { |p| { value: p.id, text: p.name } }.to_json %>"

--- a/app/views/results/new.html.erb
+++ b/app/views/results/new.html.erb
@@ -1,13 +1,16 @@
 <div class="p-4">
+  <h1 class="mb-4">Add result: <%= @game.name %></h1>
 
   <% if team_game? %>
-    <h1 class="mb-4">Team Results</h1>
-    <p class="mb-4">
-      This game supports team results. This means that you can either select a singular player per team, or multiple.
-      <% if @result.teams.length > 2 %>
-        You do not need to fill in every team, start on the far left and move towards the right, the minimum requirement is the first two, then the rest are optional.
-      <% end %>
-    </p>
+    <div class="bg-blue-100 border border-blue-800 w-1/2 mx-auto p-4 mb-4">
+      <h2 class="mb-4 text-center">Team Results</h2>
+      <p class="mb-4">
+        This game supports team results. This means that you can either select a singular player per team, or multiple.
+        <% if @result.teams.length > 2 %>
+          You do not need to fill in every team, start on the far left and move towards the right, the minimum requirement is the first two, then the rest are optional.
+        <% end %>
+      </p>
+    </div>
   <% end %>
 
   <%= form_for [@game, @result] do |f| %>
@@ -16,17 +19,24 @@
         <%= @result.errors.full_messages_for(:teams).join("; ") %>
       </div>
     <% end %>
-    <div class="flex my-4">
+    <div class="flex mt-4">
       <% @result.teams.each.with_index do |team, index| %>
-        <div class="<%= class_names("grow p-4", { "bg-team-red-light": index == 0, "bg-team-blue-light": index != 0 }) %>">
+        <div class="<%= class_names("grow p-4 pb-8 mb-4", { "bg-team-red-light": index == 0, "bg-team-blue-light": index != 0 }) %>">
           <h3 class="text-center mb-2">
             Team <%= index + 1 %>
           </h3>
-          <div class="flex justify-evenly items-center gap-8">
+          <div class="flex justify-evenly items-start gap-8">
 
             <% unless index == 0 %>
               <div class="flex flex-col items-center">
-                <%= f.number_field :against, step: 1, min: 0, class: "w-32 text-xl" %>
+                <%=
+                  f.number_field :against,
+                    step: 1,
+                    min: 0,
+                    class: "w-32 text-2xl p-4 text-center",
+                    placeholder: "Score",
+                    required: true
+                %>
                 <div class="text-red-500">
                   <%= @result.errors.messages_for(:against).join("; ") %>
                 </div>
@@ -66,7 +76,14 @@
 
             <% if index == 0 %>
               <div class="flex flex-col items-center">
-                <%= f.number_field :for, step: 1, min: 0, class: "w-32 text-xl" %>
+                <%=
+                  f.number_field :for,
+                    step: 1,
+                    min: 0,
+                    class: "w-32 text-2xl p-4 text-center",
+                    placeholder: "Score",
+                    required: true
+                %>
                 <div class="text-red-500">
                   <%= @result.errors.messages_for(:for).join("; ") %>
                 </div>
@@ -77,12 +94,8 @@
         </div>
       <% end %>
     </div>
-    <div class='form-actions'>
-      <div class="row-fluid">
-      <div class="span4" style='text-align: center'>
-        <%= f.submit class: "btn btn-primary", value: 'Save Result' %>
-      </div>
-      </div>
+    <div class="flex justify-center">
+      <%= f.submit class: "btn btn-primary text-2xl", value: "Save Result" %>
     </div>
   <% end %>
 

--- a/app/views/results/new.html.erb
+++ b/app/views/results/new.html.erb
@@ -49,6 +49,7 @@
                 data-multiselect-preload-url-value="<%= players_path(format: :json) %>"
                 data-multiselect-search-url-value="<%= players_path(format: :json) %>"
                 data-multiselect-selected-value="<%= team.players.map { |p| { value: p.id, text: p.name } }.to_json %>"
+                data-no-results-message="No matching players found"
                 data-placeholder="Search for players..."
               >
                 <%=

--- a/app/views/results/new.html.erb
+++ b/app/views/results/new.html.erb
@@ -1,8 +1,8 @@
 <div class="p-4">
 
-  <% if @team_game %>
+  <% if team_game? %>
     <h1 class="mb-4">Team Results</h1>
-    <p>
+    <p class="mb-4">
       This game supports team results. This means that you can either select a singular player per team, or multiple.
       <% if @result.teams.length > 2 %>
         You do not need to fill in every team, start on the far left and move towards the right, the minimum requirement is the first two, then the rest are optional.
@@ -11,19 +11,34 @@
   <% end %>
 
   <%= form_for [@game, @result] do |f| %>
+    <% if @result.errors.include?(:teams) %>
+      <div class="border border-red-500 bg-red-100 text-red-500 p-4 w-1/2 mx-auto">
+        <%= @result.errors.full_messages_for(:teams).join("; ") %>
+      </div>
+    <% end %>
     <div class="flex my-4">
       <% @result.teams.each.with_index do |team, index| %>
         <div class="<%= class_names("grow p-4", { "bg-team-red-light": index == 0, "bg-team-blue-light": index != 0 }) %>">
           <h3 class="text-center mb-2">
             Team <%= index + 1 %>
           </h3>
-          <div class="flex justify-center items-center gap-8">
+          <div class="flex justify-evenly items-center gap-8">
 
-            <% if @team_game %>
+            <% unless index == 0 %>
+              <div class="flex flex-col items-center">
+                <%= f.number_field :against, step: 1, min: 0, class: "w-32 text-xl" %>
+                <div class="text-red-500">
+                  <%= @result.errors.messages_for(:against).join("; ") %>
+                </div>
+              </div>
+            <% end %>
+
+            <% if team_game? %>
               <div
                 data-controller="multiselect"
                 data-multiselect-preload-url-value="<%= players_path(format: :json) %>"
                 data-multiselect-search-url-value="<%= players_path(format: :json) %>"
+                data-multiselect-selected-value="<%= team.players.map { |p| { value: p.id, text: p.name } }.to_json %>"
                 data-placeholder="Search for players..."
               >
                 <%=
@@ -50,10 +65,14 @@
             <% end %>
 
             <% if index == 0 %>
-              <%= f.number_field :for, step: 1, min: 0, class: "w-16" %>
-            <% else %>
-              <%= f.number_field :against, step: 1, min: 0, class: "w-16" %>
+              <div class="flex flex-col items-center">
+                <%= f.number_field :for, step: 1, min: 0, class: "w-32 text-xl" %>
+                <div class="text-red-500">
+                  <%= @result.errors.messages_for(:for).join("; ") %>
+                </div>
+              </div>
             <% end %>
+
           </div>
         </div>
       <% end %>

--- a/app/views/shared/_result.html.erb
+++ b/app/views/shared/_result.html.erb
@@ -4,16 +4,18 @@
     if result.for && result.against
       result_classes = if result.for > result.against
         if result.against == 0
-          result_classes = "score-red-wins-10"
+          "score-red-wins-10"
         else
-          result_classes = "score-red-wins"
+          "score-red-wins"
         end
       elsif result.against > result.for
         if result.for == 0
-          result_classes = "score-blue-wins-10"
+          "score-blue-wins-10"
         else
-          result_classes = "score-blue-wins"
+          "score-blue-wins"
         end
+      else
+        "score-draw"
       end
     end
 %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -10,3 +10,4 @@ pin_all_from 'app/javascript/controllers', under: 'controllers'
 pin 'chartkick', to: 'chartkick.js'
 pin 'Chart.bundle', to: 'Chart.bundle.js'
 pin 'el-transition', to: 'https://ga.jspm.io/npm:el-transition@0.0.7/index.js'
+pin "@wizardhealth/stimulus-multiselect", to: "https://ga.jspm.io/npm:@wizardhealth/stimulus-multiselect@1.0.0/src/multiselect.js"


### PR DESCRIPTION
This PR makes improvements to the "add result" page, both cosmetic and functional.

![image](https://github.com/user-attachments/assets/e60c0788-d12e-445e-8de6-73b7144d8df9)

- It's now made clear what game you're actually adding a result for, assuming you can't remember the numeric IDs from the URL
- One can type to search for player names, and the multiselect works as you'd hope (with a little bit of UI jank)
- It's also possible to add new players directly from this screen, and add them into the result:
  ![image](https://github.com/user-attachments/assets/f0d470e0-c543-4c39-a831-129702fd6c6b)
- In a demo of cutting-edge Rails technology, errors from submitting the form are actually now displayed to the user:
  ![image](https://github.com/user-attachments/assets/5cad5444-7564-43c9-8cc2-2d23b49f4020)
- As a bonus, deleting players (from the player show page) now actually works too.
- As another bonus, draws are displayed correctly in result lists.
